### PR TITLE
Instructions for libndk_translator debugging and image with GApps

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,43 @@ ro.ndk_translation.version=0.2.2
 docker build . -t redroid:11.0.0-amd64-nb
 ```
 
+Take a look at https://gitlab.com/android-generic/android_vendor_google_emu-x86 to extract automatically libndk_translator from the Android 11 emulator images. 
+
+After following the guide on "Building" section, you will get native-bridge.tar under vendor/google/emu-x86/proprietary.
+
+If you find errors in using libndk_translator, please try the following:
+
+- YOU MUST HAVE binfmt_misc kernel module loaded for supporting other binaries formats! If you have not loaded it already:
+
+  ```bash
+  sudo modprobe binfmt_misc
+  ```
+
+  or add binfmt_misc to /etc/modules to autoload it at boot (for example in Ubuntu). 
+
+  Check your specific distribution wiki/docs if you don't have binfmt_misc module and you want to install it, or how to autoload the module at boot.
+
+- Extract the native bridge archive, preserving the permissions, set specific permissions for allowing init file to be executed and traverse of important dirs:
+
+  ```bash
+  mkdir native-bridge
+  cd native-bridge
+  sudo tar -xpf ../native-bridge.tar `#or path to your actual native bridge tarball`
+  sudo chmod 0644 system/etc/init/ndk_translation_arm64.rc
+  sudo chmod 0755 system/bin/arm
+  sudo chmod 0755 system/bin/arm64
+  sudo chmod 0755 system/lib/arm
+  sudo chmod 0755 system/lib64/arm64
+  sudo tar -cpf native-bridge.tar system
+  ```
+
+  Move or copy your new native-bridge.tar into the dir where you have written your Dockerfile, and rebuild again the new image with native bridge support. 
+  
+  You must use sudo or a root shell to preserve the permissions and owners of the files.
+
 ## GMS Support
-It's possible to add GMS (Google Mobile Service) support in *ReDroid* via [Open GApps](https://opengapps.org/) 
-or [MicroG](https://microg.org/).
+
+It's possible to add GMS (Google Mobile Service) support in *ReDroid* via [Open GApps](https://opengapps.org/), [MicroG](https://microg.org/) or [MindTheGapps](https://gitlab.com/MindTheGapps/vendor_gapps).
 
 
 ## WebRTC Streaming

--- a/android-builder-docker/README.md
+++ b/android-builder-docker/README.md
@@ -50,7 +50,38 @@ sudo tar --xattrs -c vendor -C system --exclude="vendor" . | docker import -c 'E
 tar --xattrs -c -C root . | docker import -c 'ENTRYPOINT ["/init", "qemu=1", "androidboot.hardware=redroid"]' - redroid-dev
 ```
 
+## Build with GApps
+
+You can build a ReDroid image with your favorite GApps package if you need, for simplicity there is an example with Mind The Gapps.
+
+This is not different from the normal building process, except for some small things, like:
+
+- When following the "Sync Code" paragraph,  after running the repo sync, add this manifest under .repo/local_manifests/mindthegapps.xml, for the specific ReDroid revision selected. 
+
+  For example, for Redroid 11 the revision is 'rho', and for Redroid 12 is 'sigma', and this is the expected manifest:
+
+  ```xml
+  <?xml version="1.0" encoding="UTF-8"?>
+  <manifest>
+          <remote name="mtg" fetch="https://gitlab.com/MindTheGapps/" />
+          <project path="vendor/gapps" name="vendor_gapps" revision="sigma" remote="mtg" />
+  </manifest>
+  ```
+
+- Add the path to the mk file corresponding to your selected arch to device/redroid/redroid_ARCHITECTURE/device.mk , for example we want x86_64 arch (x86 for ReDroid 11 as in 'rho' Mind The Gapps as only x86 GApps)
+
+  ```makefile
+  $(call inherit-product, vendor/gapps/x86_64/x86_64-vendor.mk)
+  ```
+
+  putting this, modified for the corresponding architecture you need. So change 'x86_64' with arm64 if you need arm64 GApps.
+
+  Resync the repo with a new 'repo sync -c --no-tags' and continue following the building guide exactly as before.
+
+- OPTIONAL but recommended. While importing the image, change the entrypoint to 'ENTRYPOINT ["/init", "qemu=1", "androidboot.hardware=redroid", "ro.setupwizard.mode=DISABLED"]' , so you avoid doing it manually at every container start, or if you want set ro.setupwizard.mode=DISABLED at container start, skipping the GApps setup wizard at ReDroid boot.
+
 ## Note
+
 ```bash
 # intent changes for redroid-10 (copyfile hook during repo sync), DO NOT PANIC
 # [Android Clang/LLVM Toolchain](https://github.com/remote-android/platform_manifests/tree/llvm-toolchain-redroid-10.0.0)


### PR DESCRIPTION
I've added MindTheGapps to the GApps list, it is the suggested from LineageOS for some Android versions https://wiki.lineageos.org/gapps . I'm adding the source of the info just to make sure that is not a strange vendor from a strange party. 

I've linked directly the latest source code in the readme, but the binaries links are in the LineageOS wiki.

I've added a section to provide better support for libndk_translator debugging, as I didn't have it working. With the specific changes I describe in the readme, it seems to work nicely.

I'm adding the needs for binfmt_misc module, because ndk_translation_arm64.rc under the hood mounts binfmt_misc for other binaries formats support, and the other chmod because I had issues traversing the dirs when the native bridge tried to access the need binaries and libraries.

As adding GApps to the built image can be annoying, I've added a section to the building guide to build an image with GApps directly on it.

I've used MindTheGapps in the example, but I've built an image with both MTG and OpenGApps, but surely building with MTG is simpler than build with OpenGApps for some reasons (like the amounts of things to ammend to build with OpenGApps while building for example for x86_64 arch). 
Building with MicroG needs a bit more effort, but I don't know if someone is really interested that must/could be documented.
I guess if you can follow the guide for MTG, and you have the skills to build the imge, you can change to MicroG without too much effort.

At least, this should answer lot of users and issues asking "how I install GApps to ReDroid?" and "Translator is not working for me, how I fix it?"

Hope this is appreciated!