### PR TITLE
Fixing unregistered interpreters (for the native bridge support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ If you find errors in using libndk_translator, please try the following:
   sudo chmod 0755 system/bin/arm64
   sudo chmod 0755 system/lib/arm
   sudo chmod 0755 system/lib64/arm64
+  sudo chmod 0644 system/etc/binfmt_misc/*
   sudo tar -cpf native-bridge.tar system
   ```
 

--- a/README.md
+++ b/README.md
@@ -149,9 +149,43 @@ ro.ndk_translation.version=0.2.2
 docker build . -t redroid:11.0.0-amd64-nb
 ```
 
+Take a look at https://gitlab.com/android-generic/android_vendor_google_emu-x86 to extract automatically libndk_translator from the Android 11 emulator images. 
+
+After following the guide on "Building" section, you will get native-bridge.tar under vendor/google/emu-x86/proprietary.
+
+If you find errors in using libndk_translator, please try the following:
+
+- YOU MUST HAVE binfmt_misc kernel module loaded for supporting other binaries formats! If you have not loaded it already:
+
+  ```bash
+  sudo modprobe binfmt_misc
+  ```
+
+  or add binfmt_misc to /etc/modules to autoload it at boot (for example in Ubuntu). 
+
+  Check your specific distribution wiki/docs if you don't have binfmt_misc module and you want to install it, or how to autoload the module at boot.
+
+- Extract the native bridge archive, preserving the permissions, set specific permissions for allowing init file to be executed and traverse of important dirs:
+
+  ```bash
+  mkdir native-bridge
+  cd native-bridge
+  sudo tar -xpf ../native-bridge.tar `#or path to your actual native bridge tarball`
+  sudo chmod 0644 system/etc/init/ndk_translation_arm64.rc
+  sudo chmod 0755 system/bin/arm
+  sudo chmod 0755 system/bin/arm64
+  sudo chmod 0755 system/lib/arm
+  sudo chmod 0755 system/lib64/arm64
+  sudo tar -cpf native-bridge.tar system
+  ```
+
+  Move or copy your new native-bridge.tar into the dir where you have written your Dockerfile, and rebuild again the new image with native bridge support. 
+  
+  You must use sudo or a root shell to preserve the permissions and owners of the files.
+
 ## GMS Support
-It's possible to add GMS (Google Mobile Service) support in *ReDroid* via [Open GApps](https://opengapps.org/) 
-or [MicroG](https://microg.org/).
+
+It's possible to add GMS (Google Mobile Service) support in *ReDroid* via [Open GApps](https://opengapps.org/), [MicroG](https://microg.org/) or [MindTheGapps](https://gitlab.com/MindTheGapps/vendor_gapps).
 
 
 ## WebRTC Streaming

--- a/android-builder-docker/README.md
+++ b/android-builder-docker/README.md
@@ -50,7 +50,38 @@ sudo tar --xattrs -c vendor -C system --exclude="vendor" . | docker import -c 'E
 tar --xattrs -c -C root . | docker import -c 'ENTRYPOINT ["/init", "qemu=1", "androidboot.hardware=redroid"]' - redroid-dev
 ```
 
+## Build with GApps
+
+You can build a ReDroid image with your favorite GApps package if you need, for simplicity there is an example with Mind The Gapps.
+
+This is not different from the normal building process, except for some small things, like:
+
+- When following the "Sync Code" paragraph,  after running the repo sync, add this manifest under .repo/local_manifests/mindthegapps.xml, for the specific ReDroid revision selected. 
+
+  For example, for Redroid 11 the revision is 'rho', and for Redroid 12 is 'sigma', and this is the expected manifest:
+
+  ```xml
+  <?xml version="1.0" encoding="UTF-8"?>
+  <manifest>
+          <remote name="mtg" fetch="https://gitlab.com/MindTheGapps/" />
+          <project path="vendor/gapps" name="vendor_gapps" revision="sigma" remote="mtg" />
+  </manifest>
+  ```
+
+- Add the path to the mk file corresponding to your selected arch to device/redroid/redroid_ARCHITECTURE/device.mk , for example we want x86_64 arch (x86 for ReDroid 11 as in 'rho' Mind The Gapps as only x86 GApps)
+
+  ```makefile
+  $(call inherit-product, vendor/gapps/x86_64/x86_64-vendor.mk)
+  ```
+
+  putting this, modified for the corresponding architecture you need. So change 'x86_64' with arm64 if you need arm64 GApps.
+
+  Resync the repo with a new 'repo sync -c --no-tags' and continue following the building guide exactly as before.
+
+- OPTIONAL but recommended. While importing the image, change the entrypoint to 'ENTRYPOINT ["/init", "qemu=1", "androidboot.hardware=redroid", "ro.setupwizard.mode=DISABLED"]' , so you avoid doing it manually at every container start, or if you want set ro.setupwizard.mode=DISABLED at container start, skipping the GApps setup wizard at ReDroid boot.
+
 ## Note
+
 ```bash
 # intent changes for redroid-10 (copyfile hook during repo sync), DO NOT PANIC
 # [Android Clang/LLVM Toolchain](https://github.com/remote-android/platform_manifests/tree/llvm-toolchain-redroid-10.0.0)


### PR DESCRIPTION
I'm human, so I can make mistakes.
I've not seen before this:
```
[40803.298930] init: processing action (ro.enable.native.bridge.exec=1) from (/system/etc/init/ndk_translation_arm64.rc:5)
[40803.298979] init: Command 'copy /system/etc/binfmt_misc/arm_exe /proc/sys/fs/binfmt_misc/register' action=ro.enable.native.bridge.exec=1 (/system/etc/init/ndk_translation_arm64.rc:6) took 0ms and failed: Could not read input file '/system/etc/binfmt_misc/arm_exe': Skipping insecure file
[40803.299011] init: Command 'copy /system/etc/binfmt_misc/arm_dyn /proc/sys/fs/binfmt_misc/register' action=ro.enable.native.bridge.exec=1 (/system/etc/init/ndk_translation_arm64.rc:7) took 0ms and failed: Could not read input file '/system/etc/binfmt_misc/arm_dyn': Skipping insecure file
[40803.299036] init: Command 'copy /system/etc/binfmt_misc/arm64_exe /proc/sys/fs/binfmt_misc/register' action=ro.enable.native.bridge.exec=1 (/system/etc/init/ndk_translation_arm64.rc:8) took 0ms and failed: Could not read input file '/system/etc/binfmt_misc/arm64_exe': Skipping insecure file
[40803.299058] init: Command 'copy /system/etc/binfmt_misc/arm64_dyn /proc/sys/fs/binfmt_misc/register' action=ro.enable.native.bridge.exec=1 (/system/etc/init/ndk_translation_arm64.rc:9) took 0ms and failed: Could not read input file '/system/etc/binfmt_misc/arm64_dyn': Skipping insecure file
```

This commit fix this, chmodding the correct permissions to the files.

After, they are registered with the others on the system:

```
ls /proc/sys/fs/binfmt_misc/                                                                                                                                                                                                                        
arm64_dyn  arm_dyn  cli  python2.7  qemu-aarch64  qemu-arm    qemu-cris     qemu-hppa  qemu-microblaze  qemu-mips64    qemu-mipsel   qemu-mipsn32el  qemu-ppc64    qemu-riscv32  qemu-s390x  qemu-sh4eb  qemu-sparc32plus  qemu-xtensa    register
arm64_exe  arm_exe  jar  python3.9  qemu-alpha    qemu-armeb  qemu-hexagon  qemu-m68k  qemu-mips        qemu-mips64el  qemu-mipsn32  qemu-ppc        qemu-ppc64le  qemu-riscv64  qemu-sh4    qemu-sparc  qemu-sparc64      qemu-xtensaeb  status
```
I really have not seen any particular negative behaviour without them registered, but well just to be sure...