### PR TITLE
Update android-builder-docker | README

### DIFF
--- a/android-builder-docker/README.md
+++ b/android-builder-docker/README.md
@@ -45,6 +45,9 @@ repo sync -c -j$(nproc)
 
 # get latest Dockerfile from Redroid repository
 wget https://raw.githubusercontent.com/remote-android/redroid-doc/master/android-builder-docker/Dockerfile
+
+# check if 'Webview.apk' files were properly synced by 'git-lfs'. Each .apk should be at least ~80MB in size.
+find ~/redroid/external/chromium-webview -type f -name "*.apk" -exec du -h {} +
 ```
 #### 3) GApps (optional)
 ##### In case you want to add GApps to your build (PlayStore, etc), you can follow these steps, otherwise, just skip it

--- a/android-builder-docker/README.md
+++ b/android-builder-docker/README.md
@@ -1,99 +1,146 @@
-# Build redroid with docker
+# Build Redroid with Docker
+```
+WARNING: YOU NEED ~180GB OF FREE SPACE ON HDD TO COMPLETE THE WHOLE PROCESS
+```
+#### 1) Setup
+```
+# update and install packages
+sudo apt-get update -y && sudo apt-get upgrade -y && sudo apt-get install -y curl libxml2-utils docker.io docker-buildx git-lfs jq
+sudo apt-get remove repo -y && sudo apt-get autoremove -y
 
-```bash
-#####################
-# fetch code
-#####################
+# install 'repo'
+mkdir -p ~/.bin
+curl https://storage.googleapis.com/git-repo-downloads/repo > ~/.bin/repo
+chmod a+x ~/.bin/repo
+echo 'export PATH=~/.bin:$PATH' >> ~/.bashrc && source ~/.bashrc
+
+# set git variables
+git config --global user.email "you@example.com"
+git config --global user.name "Your Name"
+
+# add current user to Docker group so we don't have to type 'sudo' to run Docker
+sudo usermod -aG docker ubuntu # Set your username here
+sudo systemctl enable docker
+sudo systemctl restart docker
+
+# NOW YOU SHOULD LOGOUT AND LOGIN AGAIN FOR DOCKER TO RECOGNIZE OUR USER
+
+# check if Docker is running
+docker --version && docker ps -as
+Docker version 24.0.5, build 24.0.5-0ubuntu1~22.04.1
+CONTAINER ID   IMAGE     COMMAND   CREATED   STATUS    PORTS     NAMES     SIZE
+```
+#### 2) Fetch and sync Android and Redroid codes
+```
 mkdir ~/redroid && cd ~/redroid
 
 # check supported branch in https://github.com/remote-android/redroid-patches.git
-repo init -u https://android.googlesource.com/platform/manifest --git-lfs --depth=1 -b android-11.0.0_r48
+repo init -u https://android.googlesource.com/platform/manifest --git-lfs --depth=1 -b android-12.0.0_r34
 
 # add local manifests
-git clone https://github.com/remote-android/local_manifests.git ~/redroid/.repo/local_manifests -b 11.0.0
+git clone https://github.com/remote-android/local_manifests.git ~/redroid/.repo/local_manifests -b 12.0.0
 
-# sync code
+# sync code | ~100GB of data | ~20 minutes on a fast CPU + connection
 repo sync -c
 
 # apply redroid patches
 git clone https://github.com/remote-android/redroid-patches.git ~/redroid-patches
 ~/redroid-patches/apply-patch.sh ~/redroid
 
-#####################
-# fetch code (LEGACY)
-#####################
-mkdir ~/redroid && cd ~/redroid
+# get latest Dockerfile from Redroid repository
+wget https://raw.githubusercontent.com/remote-android/redroid-doc/master/android-builder-docker/Dockerfile
 
-repo init -u https://github.com/remote-android/platform_manifests.git -b redroid-11.0.0 --depth=1 --git-lfs
-# check @remote-android/platform_manifests for supported branch / manifest
+# This command will pull all large files managed by Git LFS (Large File Storage) in the specified group of repositories.
+# In our case we need to pull the `Webview.apk` files that are not pulled by default
+repo forall -g lfs -c 'git lfs pull'
+```
 
-repo sync -c
+#### 3) GApps (optional)
+##### In case you want to add GApps to your build (PlayStore, etc), you can follow these steps, otherwise, just skip it
+- Add this manifest under `.repo/local_manifests/mindthegapps.xml`, for the specific redroid revision selected.
+  For example, for Redroid 11 the revision is 'rho', and for Redroid 12 is 'sigma', and this is the expected manifest:
+  ```xml
+  <?xml version="1.0" encoding="UTF-8"?>
+  <manifest>
+    <remote name="mtg" fetch="https://gitlab.com/MindTheGapps/" />
+    <project path="vendor/gapps" name="vendor_gapps" revision="sigma" remote="mtg" />
+  </manifest>
+  ```
+- Add the path to the mk file corresponding to your selected arch `~/redroid/device/redroid/redroid_ARCHITECTURE/device.mk`, for example if we want arm64 arch (arm64 for Redroid 12 as in 'sigma' Mind The Gapps, as only arm64 GApps)
+  ```
+  nano ~/redroid/device/redroid/redroid_arm64/device.mk
+  ```
+  ```makefile
+  $(call inherit-product, vendor/gapps/arm64/arm64-vendor.mk)
+  ```
+- Resync `~/redroid`
+  ```
+  repo sync -c
+  ```
+- OPTIONAL but recommended. While importing the image in the Step 6 (docker import command), change the entrypoint to 'ENTRYPOINT ["/init", "androidboot.hardware=redroid", "ro.setupwizard.mode=DISABLED"]', so you avoid doing it manually at every container start, or if you want set `ro.setupwizard.mode=DISABLED` at container start, skipping the GApps setup wizard at redroid boot. Optional line available in Step 6.
 
-#####################
-# create builder
-#####################
-docker build --build-arg userid=$(id -u) --build-arg groupid=$(id -g) --build-arg username=$(id -un) -t redroid-builder .
-
-#####################
-# start builder
-#####################
-docker run -it --rm --hostname redroid-builder --name redroid-builder -v ~/redroid:/src redroid-builder
-
-#####################
-# build redroid
-#####################
+#### 4) Create and start builder
+```
+docker buildx create --use
+docker buildx build --build-arg userid=$(id -u) --build-arg groupid=$(id -g) --build-arg username=$(id -un) -t redroid-builder --load .
+docker run -it --privileged --rm --hostname redroid-builder --name redroid-builder -v ~/redroid:/src redroid-builder
+```
+#### 5) Build Redroid
+#### Now we should be in the `redroid-builder` docker container
+```
 cd /src
-
 . build/envsetup.sh
 
-lunch redroid_x86_64-userdebug
+lunch redroid_arm64-userdebug
+# redroid_x86_64-userdebug
 # redroid_arm64-userdebug
 # redroid_x86_64_only-userdebug (64 bit only, redroid 12+)
 # redroid_arm64_only-userdebug (64 bit only, redroid 12+)
 
-# start to build
-m
+# start to build | + ~50GB of data
+m -j${nproc}
 
-#####################
-# create redroid image in *HOST*
-#####################
-cd ~/redroid/out/target/product/redroid_x86_64
-
+exit
+```
+#### 6) Create Redroid image in *HOST*
+```
+cd ~/redroid/out/target/product/redroid_arm64
 sudo mount system.img system -o ro
 sudo mount vendor.img vendor -o ro
-sudo tar --xattrs -c vendor -C system --exclude="./vendor" . | docker import -c 'ENTRYPOINT ["/init", "androidboot.hardware=redroid"]' - redroid
+
+# set the target platform or multiplatform for this Docker image we're creating with the --platform flag in 'docker import' command below
+# docker import --platform=linux/arm64,linux/amd64 .... etc
+
+sudo tar --xattrs -c vendor -C system --exclude="./vendor" . | docker import --platform=linux/arm64 -c 'ENTRYPOINT ["/init", "qemu=1", "androidboot.hardware=redroid"]' - redroid
+# execute only ↑ (without Step 3 Gapps) or ↓ (with Step 3 Gapps) | (OPTIONAL)
+sudo tar --xattrs -c vendor -C system --exclude="./vendor" . | docker import --platform=linux/arm64 -c 'ENTRYPOINT ["/init", "qemu=1", "androidboot.hardware=redroid", "ro.setupwizard.mode=DISABLED"]' - redroid
+
 sudo umount system vendor
 
-# create rootfs only image for develop purpose
+# create rootfs only image for develop purpose (Optional)
 tar --xattrs -c -C root . | docker import -c 'ENTRYPOINT ["/init", "androidboot.hardware=redroid"]' - redroid-dev
+
+# inspect the created image to see if everything is ok
+docker inspect redroid:latest | jq '.[0].Config.Entrypoint, .[0].Architecture'
+[
+  "/init",
+  "qemu=1",
+  "androidboot.hardware=redroid"
+]
+"arm64"
 ```
+#### 7) Tag and push image to Docker Hub
+##### Now you can tag the docker image to your personal docker account and push it to Docker Hub
+```
+# Get the container ID of the imported Docker image
+docker images
+REPOSITORY             TAG                              IMAGE ID       CREATED         SIZE
+redroid                latest                           b00684099b2d   9 minutes ago   1.91GB
 
-## Build with GApps
+# Tag it
+docker tag b00684099b2d YourDockerAccount/redroid:12.0.0_arm64-latest
 
-You can build a redroid image with your favorite GApps package if you need, for simplicity there is an example with Mind The Gapps.
-
-This is not different from the normal building process, except for some small things, like:
-
-- When following the "Sync Code" paragraph,  after running the repo sync, add this manifest under .repo/local_manifests/mindthegapps.xml, for the specific redroid revision selected.
-
-  For example, for Redroid 11 the revision is 'rho', and for Redroid 12 is 'sigma', and this is the expected manifest:
-
-  ```xml
-  <?xml version="1.0" encoding="UTF-8"?>
-  <manifest>
-          <remote name="mtg" fetch="https://gitlab.com/MindTheGapps/" />
-          <project path="vendor/gapps" name="vendor_gapps" revision="sigma" remote="mtg" />
-  </manifest>
-  ```
-
-- Add the path to the mk file corresponding to your selected arch to `device/redroid/redroid_ARCHITECTURE/device.mk` , for example we want x86_64 arch (x86 for redroid 11 as in 'rho' Mind The Gapps as only x86 GApps)
-
-  ```makefile
-  $(call inherit-product, vendor/gapps/x86_64/x86_64-vendor.mk)
-  ```
-
-  putting this, modified for the corresponding architecture you need. So change 'x86_64' with arm64 if you need arm64 GApps.
-
-  Resync the repo with a new `repo sync -c` and continue following the building guide exactly as before.
-
-- OPTIONAL but recommended. While importing the image, change the entrypoint to 'ENTRYPOINT ["/init", "androidboot.hardware=redroid", "ro.setupwizard.mode=DISABLED"]' , so you avoid doing it manually at every container start, or if you want set `ro.setupwizard.mode=DISABLED` at container start, skipping the GApps setup wizard at redroid boot.
+# Push it to Docker Hub
+docker login
+docker push YourDockerAccount/redroid:12.0.0_arm64-latest
+```

--- a/android-builder-docker/README.md
+++ b/android-builder-docker/README.md
@@ -27,8 +27,8 @@ sudo systemctl restart docker
 
 # check if Docker is running
 docker --version && docker ps -as
-Docker version 24.0.5, build 24.0.5-0ubuntu1~22.04.1
-CONTAINER ID   IMAGE     COMMAND   CREATED   STATUS    PORTS     NAMES     SIZE
+# Docker version 24.0.5, build 24.0.5-0ubuntu1~22.04.1
+# CONTAINER ID   IMAGE     COMMAND   CREATED   STATUS    PORTS     NAMES     SIZE
 ```
 #### 2) Fetch and sync Android and Redroid codes
 ```

--- a/android-builder-docker/README.md
+++ b/android-builder-docker/README.md
@@ -57,7 +57,7 @@ wget https://raw.githubusercontent.com/remote-android/redroid-doc/master/android
     <project path="vendor/gapps" name="vendor_gapps" revision="sigma" remote="mtg" />
   </manifest>
   ```
-  You can add manually ↑ or with this 1 line command that will create and write to the file ↓ (remember to set proper revision)
+  You can add manually **↑** or with this 1 line command **↓** that will create and write to the file (remember to set proper revision)
   ```
   echo -e '<?xml version="1.0" encoding="UTF-8"?>\n<manifest>\n  <remote name="mtg" fetch="https://gitlab.com/MindTheGapps/" />\n  <project path="vendor/gapps" name="vendor_gapps" revision="sigma" remote="mtg" />\n</manifest>' > ~/redroid/.repo/local_manifests/mindthegapps.xml
   ```
@@ -68,17 +68,17 @@ wget https://raw.githubusercontent.com/remote-android/redroid-doc/master/android
   ```makefile
   $(call inherit-product, vendor/gapps/arm64/arm64-vendor.mk)
   ```
-
-- Patch GApps files
+- Resync `~/redroid` | Fetch GApps code
   ```
-  # You can run the lines below from within the Docker container "/src" or outside of it "~/redroid/" (in the host).
-  # Set the correct path of your choice before running them
-  
-  # First we comment out some lines in "vendor/gapps/arm64/arm64-vendor.mk"
-  sed -i '/^PRODUCT_COPY_FILES += /s/^/#/' vendor/gapps/arm64/arm64-vendor.mk
-  sed -i '/vendor\/gapps\/arm64\/proprietary\/product/s/^/#/' vendor/gapps/arm64/arm64-vendor.mk
+  repo sync -c -j$(nproc)
+  ```
+- Patch GApps files
+  ```  
+  # First we comment out some lines in "~/redroid/vendor/gapps/arm64/arm64-vendor.mk"
+  sed -i '/^PRODUCT_COPY_FILES += /s/^/#/' ~/redroid/vendor/gapps/arm64/arm64-vendor.mk
+  sed -i '/vendor\/gapps\/arm64\/proprietary\/product/s/^/#/' ~/redroid/vendor/gapps/arm64/arm64-vendor.mk
 
-  # Then we create the "vendor/gapps/arm64/proprietary/product/app/MarkupGoogle/Android.bp"
+  # Then we create the "~/redroid/vendor/gapps/arm64/proprietary/product/app/MarkupGoogle/Android.bp"
   echo 'cc_prebuilt_library_shared {
       name: "libsketchology_native",
       srcs: ["lib/arm64/libsketchology_native.so"],
@@ -86,16 +86,12 @@ wget https://raw.githubusercontent.com/remote-android/redroid-doc/master/android
       stl: "none",
       system_shared_libs: [],
       vendor: true,
-  }' > vendor/gapps/arm64/proprietary/product/app/MarkupGoogle/Android.bp
+  }' > ~/redroid/vendor/gapps/arm64/proprietary/product/app/MarkupGoogle/Android.bp
 
-  # And add some entries to the end of "vendor/gapps/arm64/Android.bp" file
-  sed -i '$a cc_prebuilt_library_shared {\n    name: "libjni_latinimegoogle",\n    srcs: ["proprietary/product/lib/libjni_latinimegoogle.so"],\n    shared_libs: [],\n    stl: "none",\n    system_shared_libs: [],\n    vendor: true,\n}\n\ncc_prebuilt_library_shared {\n    name: "libjni_latinimegoogle_64",\n    srcs: ["proprietary/product/lib64/libjni_latinimegoogle.so"],\n    shared_libs: [],\n    stl: "none",\n    system_shared_libs: [],\n    vendor: true,\n}' vendor/gapps/arm64/Android.bp
+  # And add some entries to the end of "~/redroid/vendor/gapps/arm64/Android.bp" file
+  sed -i '$a cc_prebuilt_library_shared {\n    name: "libjni_latinimegoogle",\n    srcs: ["proprietary/product/lib/libjni_latinimegoogle.so"],\n    shared_libs: [],\n    stl: "none",\n    system_shared_libs: [],\n    vendor: true,\n}\n\ncc_prebuilt_library_shared {\n    name: "libjni_latinimegoogle_64",\n    srcs: ["proprietary/product/lib64/libjni_latinimegoogle.so"],\n    shared_libs: [],\n    stl: "none",\n    system_shared_libs: [],\n    vendor: true,\n}' ~/redroid/vendor/gapps/arm64/Android.bp
   ```
   
-- Resync `~/redroid`
-  ```
-  repo sync -c -j$(nproc)
-  ```
 - OPTIONAL (recommended)
   
   While importing the image in the Step 6 (docker import command), change the entrypoint to `ENTRYPOINT ["/init", "androidboot.hardware=redroid", "ro.setupwizard.mode=DISABLED"]`, so you avoid doing it manually at every container start, or if you want set `ro.setupwizard.mode=DISABLED` at container start, skipping the GApps setup wizard at redroid boot. Optional line available in Step 6.

--- a/deploy/wsl.md
+++ b/deploy/wsl.md
@@ -34,6 +34,8 @@ CONFIG_ANDROID_BINDER_IPC=y
 CONFIG_ANDROID_BINDERFS=y
 CONFIG_ANDROID_BINDER_DEVICES="binder,hwbinder,vndbinder"
 
+## install required libraries to build kernel
+sudo apt install make gcc flex bison libssl-dev libelf-dev dwarves -y
 
 ## build kernel
 make


### PR DESCRIPTION
- Improved + complete step-by-step
- Replace `BUILD` with `BUILDX` to avoid unecessary data duplication when creating the builder container.
- Fix patch to avoid errors when building with GApps